### PR TITLE
Fix hero details columns

### DIFF
--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -5,7 +5,7 @@ import {Wrapper, PizzaPosition, TopHero, SubHero, TrustSection, QuoteSection, De
 import {gucci, go, graphql, electron, next, sauceFull, bdougie} from "../images";
 import {logo1 as logo} from "../logos";
 import {archive, mortarBoard, watch, squirrel} from "../icons";
-import {Flex, FlexColumn, FloatLeft, FloatRight} from "../styles/Grid";
+import {Flex, FlexColumn, GridColumns} from "../styles/Grid";
 
 function Hero({handleLogIn}) {
   return (
@@ -88,49 +88,45 @@ function Hero({handleLogIn}) {
       </QuoteSection>
       <DetailsSection>
         <Wrapper>
-          <Flex>
-            <FloatLeft>
-              <Flex className="detail">
-                <img alt="open sauced" src={archive} />
-                <FlexColumn className="copy">
-                  <h2>Contributor issue tracking and triaging</h2>
-                  <p>
-                    Working on good-first-issues has never been easier. Create and track your contribution wishlist all
-                    in one dashboard.
-                  </p>
-                </FlexColumn>
-              </Flex>
-              <Flex className="detail">
-                <img alt="open sauced" src={mortarBoard} />
-                <FlexColumn className="copy">
-                  <h2>Structured onboarding for new contributors</h2>
-                  <p>
-                    Starting a new contribution is challenging when there is no guide. Easily find projects with
-                    structured contributor onboarding.
-                  </p>
-                </FlexColumn>
-              </Flex>
-            </FloatLeft>
-            <FloatRight>
-              <Flex className="detail">
-                <img alt="open sauced" src={watch} />
-                <FlexColumn className="copy">
-                  <h2>Scheduled reminders</h2>
-                  <p>Get notified when the contributions you are following change status or are closed.</p>
-                </FlexColumn>
-              </Flex>
-              <Flex className="detail">
-                <img alt="open sauced" src={squirrel} />
-                <FlexColumn className="copy">
-                  <h2>Find community and mentorship from approved projects</h2>
-                  <p>
-                    No more guessing what issues are ups for grabs. Through mentorship and community you will be first
-                    to know what issues are ups-for-grabs.
-                  </p>
-                </FlexColumn>
-              </Flex>
-            </FloatRight>
-          </Flex>
+          <GridColumns columns={2}>
+            <Flex className="detail">
+              <img alt="open sauced" src={archive} />
+              <FlexColumn className="copy">
+                <h2>Contributor issue tracking and triaging</h2>
+                <p>
+                  Working on good-first-issues has never been easier. Create and track your contribution wishlist all
+                  in one dashboard.
+                </p>
+              </FlexColumn>
+            </Flex>
+            <Flex className="detail">
+              <img alt="open sauced" src={mortarBoard} />
+              <FlexColumn className="copy">
+                <h2>Structured onboarding for new contributors</h2>
+                <p>
+                  Starting a new contribution is challenging when there is no guide. Easily find projects with
+                  structured contributor onboarding.
+                </p>
+              </FlexColumn>
+            </Flex>
+            <Flex className="detail">
+              <img alt="open sauced" src={watch} />
+              <FlexColumn className="copy">
+                <h2>Scheduled reminders</h2>
+                <p>Get notified when the contributions you are following change status or are closed.</p>
+              </FlexColumn>
+            </Flex>
+            <Flex className="detail">
+              <img alt="open sauced" src={squirrel} />
+              <FlexColumn className="copy">
+                <h2>Find community and mentorship from approved projects</h2>
+                <p>
+                  No more guessing what issues are ups for grabs. Through mentorship and community you will be first
+                  to know what issues are ups-for-grabs.
+                </p>
+              </FlexColumn>
+            </Flex>
+          </GridColumns>
         </Wrapper>
       </DetailsSection>
     </React.Fragment>

--- a/src/styles/Grid/GridColumns.js
+++ b/src/styles/Grid/GridColumns.js
@@ -1,0 +1,13 @@
+import styled from "styled-components";
+import MEDIA from "../mediaTemplates";
+
+const GridColumns = styled.div`
+  display: grid;
+  grid-template-columns: repeat(${props => props.columns || 1}, 1fr);
+
+  ${MEDIA.TABLET`
+    grid-template-columns: repeat(1, 1fr);
+  `};
+`;
+
+export default GridColumns;

--- a/src/styles/Grid/index.js
+++ b/src/styles/Grid/index.js
@@ -2,6 +2,7 @@ import {Flex, FlexStart, FlexColumnCenter, FlexColumn, FlexCenter, FlexHeader, S
 import IssuesColumn from "./IssuesColumn";
 import FormColumn from "./FormColumn";
 import {FloatLeftMobileNav, FloatRight, FloatLeft} from "./Float";
+import GridColumns from "./GridColumns";
 
 export {
   SpaceAround,
@@ -16,5 +17,6 @@ export {
   FormColumn,
   FloatLeft,
   FloatRight,
-  FloatLeftMobileNav
+  FloatLeftMobileNav,
+  GridColumns
 };

--- a/src/styles/Header/Hero.js
+++ b/src/styles/Header/Hero.js
@@ -216,7 +216,7 @@ const DetailsSection = styled(Hero)`
     text-align: left;
   }
   img {
-    float: left;
+    align-self: flex-start;
     margin-right: 20px;
     min-width: 30px;
     ${MEDIA.TABLET`


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/master/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/master/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🔖 Release
- [ ] 🚩 Other

## Description

This PR adds a styled component called `GridColumns`, which allows you to pass in a number of columns for `grid-template-columns` & also uses `display: grid`. By default, without a `columns` prop value, `grid-template-columns` will just repeat 1 column.

I think this type of change would be useful to the "details" section of the `Hero` component. Since that part of the page has content with varying height, `display: grid` will help ensure that each "detail" section is aligned by making the content conform to the grid layout.

In summary:

### Added

- `GridColumns` styled component

### Changed

- Replaced `FloatLeft`, `FloatRight`, and `Flex` usage in the "details" section of the `Hero` component with the new `GridColumns` styled component
- Changed image styles for the "details" section from `float: left` to `align-self: flex-start`
  **NOTE:** I realize this is a little different than what you had before, and isn't quite related to #623, but without this style update, the images are vertically centered & I thought that didn't look quite right after making the grid changes described above. With this style change though, the images will all be positioned in the same location, regardless of how much text is in a "detail" section. But please let me know if you disagree & I'd be happy to change it back! 👍 

Screenshot:

<img width="944" alt="Screen Shot 2020-06-11 at 7 58 16 PM" src="https://user-images.githubusercontent.com/9057921/84453638-fb65c000-ac1d-11ea-9bb0-ca72800beb2c.png">


## Related Tickets & Documents

Resolves #623 


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 readme
- [x] 🙅 no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

No I don't think so. 👍 

## [optional] What gif best describes this PR or how it makes you feel?

![BMO from Adventure Time is dancing.](https://user-images.githubusercontent.com/9057921/84452083-6dd4a100-ac1a-11ea-8e20-2a1642630dd3.gif)

