### PR TITLE
Fix Issue #807:  App crashes if OneGraph token has expired

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,25 +9,16 @@ import OneGraphApolloClient from "onegraph-apollo-client";
 import {ApolloProvider} from "react-apollo";
 import api from "./lib/apiGraphQL";
 import {getAppVersion} from "./lib/appVersion";
+import {validateToken} from "./lib/validateToken";
 
 const apolloClient = new OneGraphApolloClient({
   oneGraphAuth: Config.auth,
 });
 
-// OneGraph has an expire date on the token it stores in local storage
-// check to make sure the token hasn't expired
-const IsTokenValid = () => {
-  try {
-    return Config.auth.tokenExpireDate() > Date.now();
-  } catch (e) {
-    console.log(`Error checking valid: ${e}`);
-    return false;
-  }
-};
 
 function Index() {
   const [user, setUser] = useState(null);
-  const [loggedInStatus, setLogin] = useState(JSON.parse(localStorage.getItem("isLoggedIn")) && IsTokenValid());
+  const [loggedInStatus, setLogin] = useState(JSON.parse(localStorage.getItem("isLoggedIn")) && validateToken(Config.auth));
   const [isAdmin, setIsAdmin] = useState(null);
 
   useEffect(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -14,9 +14,20 @@ const apolloClient = new OneGraphApolloClient({
   oneGraphAuth: Config.auth,
 });
 
+// OneGraph has an expire date on the token it stores in local storage
+// check to make sure the token hasn't expired
+const IsTokenValid = () => {
+  try {
+    return Config.auth.tokenExpireDate() > Date.now();
+  } catch (e) {
+    console.log(`Error checking valid: ${e}`);
+    return false;
+  }
+};
+
 function Index() {
   const [user, setUser] = useState(null);
-  const [loggedInStatus, setLogin] = useState(localStorage.getItem("isLoggedIn"));
+  const [loggedInStatus, setLogin] = useState(JSON.parse(localStorage.getItem("isLoggedIn")) && IsTokenValid());
   const [isAdmin, setIsAdmin] = useState(null);
 
   useEffect(() => {

--- a/src/lib/validateToken.js
+++ b/src/lib/validateToken.js
@@ -1,0 +1,10 @@
+// OneGraph has an expire date on the token it stores in local storage
+// check to make sure the token hasn't expired
+export function validateToken(auth) {
+  try {
+    return auth.tokenExpireDate() > Date.now();
+  } catch (e) {
+    console.log(`Error checking valid: ${e}`);
+    return false;
+  }
+}

--- a/src/lib/validateToken.test.js
+++ b/src/lib/validateToken.test.js
@@ -1,0 +1,22 @@
+import {validateToken} from './validateToken'
+
+describe("Test: validateToken()", () => {
+    test("valid token", () => {
+        const tomorrow = new Date() 
+        tomorrow.setDate(tomorrow.getDate() + 1)
+        console.log(tomorrow)
+        const result = validateToken({
+            tokenExpireDate: () => tomorrow
+        })
+        expect(result).toBe(true);
+    });
+  
+    test("invalid token: token expired", () => {
+        const yesterday = new Date()
+        yesterday.setDate(yesterday.getDate() - 1)
+        const result = validateToken({
+            tokenExpireDate: () => yesterday
+        })
+      expect(result).toBe(false);
+    });
+});

--- a/src/lib/validateToken.test.js
+++ b/src/lib/validateToken.test.js
@@ -4,7 +4,6 @@ describe("Test: validateToken()", () => {
     test("valid token", () => {
         const tomorrow = new Date() 
         tomorrow.setDate(tomorrow.getDate() + 1)
-        console.log(tomorrow)
         const result = validateToken({
             tokenExpireDate: () => tomorrow
         })


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🔖 Release
- [ ] 🚩 Other

## Description
Fixes issue where the app will crash if the OneGraph token was expired and the LoggedInStatus is set to true. 
The fix is to validate the token by checking the expireDate when setting the LoggedInStatus.

## Related Tickets & Documents
fixes: #807 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)



## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 readme
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?


![](https://media3.giphy.com/media/9P5g2bLdazl3gqIO6q/200w.gif?cid=ecf05e478qi6sgpnbmf73jenzeyxyfsf16bh5xjfp2d32qsg&rid=200w.gif)

