### PR TITLE
fixing nav menu links to have tabIndex

### DIFF
--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -45,11 +45,11 @@ function LeftSide({isLoggedIn, user, handleLogIn, handleLogOut}) {
         <li>
           {isLoggedIn ? (
             <div>
-              <SubtleLink alt="log in" onClick={_logOutRedirect}>Logout</SubtleLink>
+              <SubtleLink tabIndex={0} onClick={_logOutRedirect}>Logout</SubtleLink>
             </div>
           ) : (
             <div>
-              <SubtleLink alt="log out" onClick={handleLogIn}>Login</SubtleLink>
+              <SubtleLink tabIndex={0} onClick={handleLogIn}>Login</SubtleLink>
             </div>
           )}
         </li>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [X] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🔖 Release
- [ ] 🚩 Other

## Description

Right now, if you use the "tab" key to navigate through the page, the Login/Logout links are skipped (they are `<a>` tags w no `href` so they are skipped in tabbing). This adds `tabindex` to fix that behavior.

I also cleaned up the `alt` attribute on that link because `alt` is not a valid attribute for `a` links (and it looks like they were being misused as descriptions of what an alternate link would be and not even the `title` of the link).

## Related Tickets & Documents
<!-- Please use this format link issue numbers: Fixes #123 https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword-->


## Mobile & Desktop Screenshots/Recordings (if there are UI changes)



## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 readme
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
no


## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deletes sections will be marked invalid invalid -->

