### PR TITLE
feat: update notebox story

### DIFF
--- a/src/styles/Typography/SubtleLink.js
+++ b/src/styles/Typography/SubtleLink.js
@@ -2,11 +2,17 @@ import styled from "styled-components";
 import {fontSize, colors} from "../variables";
 
 const SubtleLink = styled.a`
-  color: ${colors.offWhite} !important;
+  color: ${colors.lightGrey} !important;
   text-decoration: none;
   font-weight: bold;
   font-size: ${fontSize.default};
   margin-right: 8px;
+  
+  body.dark & {
+    a: {
+      color: ${colors.lightestGrey} !important;
+    }
+  }
 `;
 
 export default SubtleLink;

--- a/stories/2-Card.stories.js
+++ b/stories/2-Card.stories.js
@@ -154,10 +154,10 @@ export const NewRepoCard = () => (
 export const NoteCard = () => (
   <Card>
     <div>
-      <SubtleLink href="#" className="menu-link">OpenSaucedUser</SubtleLink>
+      <SubtleLink href="#" rel="noreferrer">Basic Template</SubtleLink>
     </div>
     <TextArea
-      style={{minHeight: 170}}
+      style={{minHeight: 170, marginTop: "16px"}}
       className="utility-input boxed-input text-box light-shadow"
       value={""}
       type="text"

--- a/stories/2-Card.stories.js
+++ b/stories/2-Card.stories.js
@@ -153,6 +153,9 @@ export const NewRepoCard = () => (
 
 export const NoteCard = () => (
   <Card>
+    <div>
+      <SubtleLink href="#" className="menu-link">OpenSaucedUser</SubtleLink>
+    </div>
     <TextArea
       style={{minHeight: 170}}
       className="utility-input boxed-input text-box light-shadow"


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [x] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🔖 Release
- [ ] 🚩 Other

## Description

<!-- Please do not leave this blank -->

This PR updates the `NoteCard` story and includes the Basic Template link. It also fixes the `SubtleLink` color in light mode.

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

Fixes #1160 

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->
### Before

![Cards-Note-Card-⋅-Storybook-before](https://user-images.githubusercontent.com/4386534/135795009-1fb182ea-f686-4e82-8978-6a27b7a3a35d.png)

### After

#### Light Mode

![Cards-Note-Card-⋅-Storybook-after-dark](https://user-images.githubusercontent.com/4386534/135795055-e65446ca-4968-4520-99ce-856f83fb68aa.png)

#### Dark Mode

![Cards-Note-Card-⋅-Storybook](https://user-images.githubusercontent.com/4386534/135795066-bed5aa8f-71c9-4db2-bcc6-d15d853fac0c.png)

### Note Box in light mode

#### Before

![NoteCard-before](https://user-images.githubusercontent.com/4386534/135795176-2902d613-aedd-4dcf-aae7-3449803409f1.png)

#### After

Light Mode:

![Open-Sauced](https://user-images.githubusercontent.com/4386534/135795217-8552cc19-a57e-4a54-a819-473a7d746f16.png)

Dark Mode:

![Open-Sauced-dark](https://user-images.githubusercontent.com/4386534/135795227-0fbc014a-a4df-4e89-be02-fe8a72f7198d.png)

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 readme
- [ ] 📜 contributing.md
- [ ] 📓 docs
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deletes sections will be marked invalid -->

