### PR TITLE
feat: Update pr-compliance-action

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -25,10 +25,8 @@ jobs:
     name: PR Compliance Checks
     runs-on: ubuntu-latest
     steps:
-      - uses: mtfoley/pr-compliance-action@v0.2.1
+      - uses: mtfoley/pr-compliance-action@v0.5.0
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          protected-branch: main
           body-auto-close: false
           protected-branch-auto-close: false
           watch-files: |


### PR DESCRIPTION
Update pr-compliance-action from v0.2.1 to v0.5.0

Resolves #1351 

There have been several feature releases since v0.2.1. 
- In v0.3.0 we use the default branch if `protected-branch` is not specified. 
- In v0.4.0, we use `secrets.GITHUB_TOKEN` if `repo-token` is not specified. 
- In v0.5.0, the action is less "chatty" as it uses reviews instead of regular comments and it updates the existing review instead of leaving additional comments.