### PR TITLE
feat : added social cards #1347

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,18 +1,36 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title><%= title %></title>
-    <meta name="description" content="The path to your next open-source contribution."/>
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml"/>
-    <link rel="alternate icon" href="/favicon.ico" type="image/png" sizes="16x16"/>
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180"/>
-    <link rel="mask-icon" href="/favicon.svg" color="#FFFFFF"/>
-    <meta name="msapplication-TileColor" content="#FFFFFF"/>
-    <meta name="theme-color" content="#FFFFFF"/>
+    <meta name="description" content="The path to your next open-source contribution." />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="alternate icon" href="/favicon.ico" type="image/png" sizes="16x16" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180" />
+    <link rel="mask-icon" href="/favicon.svg" color="#FFFFFF" />
+    <meta name="msapplication-TileColor" content="#FFFFFF" />
 
-    <meta property="dcterms:modified" content="<%= date %>"/>
+    <!-- For facebook, linkedin etc -->
+    <meta property="og:title" content="sauced" />
+    <meta property="og:url" content="https://app.opensauced.pizza" />
+    <meta property="og:type" content="article" />
+    <meta
+      property="og:image"
+      content="https://repository-images.githubusercontent.com/71359796/179eca00-061e-11eb-9b57-856a179db1a1"
+    />
+
+    <!-- for twitter -->
+    <meta property="twitter:title" content="sauced" />
+    <meta property="twitter:description" content="https://app.opensauced.pizza" />
+    <meta
+      property="twitter:image"
+      content="https://repository-images.githubusercontent.com/71359796/179eca00-061e-11eb-9b57-856a179db1a1"
+    />
+
+    <meta name="theme-color" content="#FFFFFF" />
+
+    <meta property="dcterms:modified" content="<%= date %>" />
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
## What type of PR is this?

- Feature

## Description

- This PR adds Social Cards as requested in https://github.com/open-sauced/open-sauced/issues/1347 by implementing Open Graph Protocol meta tags for social medias like facebook, linkedin and twitter.
- For testing  purpose, used google extension _localhost open graph checker_ that provides temporary url for checking.


## Screenshots

1. **Facebook**

![facebook_sauced](https://user-images.githubusercontent.com/58807337/162801061-676d44ba-83d2-4093-95e9-ec3f646dc49d.png)

### Meta tag supported on facebook are supported on linkedin as well 

2. **Twitter**
![titter_sauced](https://user-images.githubusercontent.com/58807337/162801468-9c54333f-9407-443f-be15-8ba13e1ee1e9.png)

## Added Tests?
No tests were added but all previous tests were passed.
![test_passed](https://user-images.githubusercontent.com/58807337/162802213-404b97d8-3130-4635-9555-d65347555541.png)


## Added Documentation?
No Documentation was necessary.





