### PR TITLE
feat: added social cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
 
     <meta
       property="twitter:description"
-      content="Open Sauced provides structured onboarding for new contributors to open source. This structure provides a way to track your next contributions by leveraging a unique dashboard built on top of the GitHub GraphQL API."
+      content="Open Sauced is a platform to gain insights on open source contributors and their contributions."
     />
     <meta
       property="twitter:image"

--- a/index.html
+++ b/index.html
@@ -1,18 +1,49 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title><%= title %></title>
-    <meta name="description" content="The path to your next open-source contribution."/>
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml"/>
-    <link rel="alternate icon" href="/favicon.ico" type="image/png" sizes="16x16"/>
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180"/>
-    <link rel="mask-icon" href="/favicon.svg" color="#FFFFFF"/>
-    <meta name="msapplication-TileColor" content="#FFFFFF"/>
-    <meta name="theme-color" content="#FFFFFF"/>
+    <meta name="description" content="The path to your next open-source contribution." />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="alternate icon" href="/favicon.ico" type="image/png" sizes="16x16" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180" />
+    <link rel="mask-icon" href="/favicon.svg" color="#FFFFFF" />
+    <meta name="msapplication-TileColor" content="#FFFFFF" />
+    <meta name="theme-color" content="#FFFFFF" />
 
-    <meta property="dcterms:modified" content="<%= date %>"/>
+    <meta property="dcterms:modified" content="<%= date %>" />
+
+    <!-- For facebook, linkedin etc -->
+    <meta property="og:title" content="Open Sauced" />
+    <meta property="og:url" content="https://app.opensauced.pizza" />
+    <meta property="og:type" content="article" />
+    <meta
+      property="og:description"
+      content="Open Sauced provides structured onboarding for new contributors to open source. This structure provides a way to track your next contributions by leveraging a unique dashboard built on top of the GitHub GraphQL API."
+    />
+    <meta
+      property="og:image"
+      content="https://repository-images.githubusercontent.com/71359796/179eca00-061e-11eb-9b57-856a179db1a1"
+    />
+
+    <!-- for twitter -->
+    <meta property="twitter:title" content="Open Sauced" />
+    <meta property="twitter:url" content="https://app.opensauced.pizza" />
+    <meta property="twitter:type" content="article" />
+
+    <meta
+      property="twitter:description"
+      content="Open Sauced provides structured onboarding for new contributors to open source. This structure provides a way to track your next contributions by leveraging a unique dashboard built on top of the GitHub GraphQL API."
+    />
+    <meta
+      property="twitter:image"
+      content="https://repository-images.githubusercontent.com/71359796/179eca00-061e-11eb-9b57-856a179db1a1"
+    />
+
+    <meta name="theme-color" content="#FFFFFF" />
+
+    <meta property="dcterms:modified" content="<%= date %>" />
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
## What type of PR is this?

- Feature

## Description

- This PR adds Social Cards as requested in https://github.com/open-sauced/open-sauced/issues/1347 by implementing Open Graph Protocol meta tags for social medias like facebook, linkedin and twitter.
- For testing purpose, used google extension localhost open graph checker that provides temporary url for checking.
- This PR closes #1347


## Screenshots
1. Facebook
- Meta tag supported on facebook are supported on linkedin as well

![facebook](https://user-images.githubusercontent.com/58807337/163296882-a2bbfa92-207e-4001-982a-10e7c784a584.png)

2. Twitter
-  Meta tag supported on Twitter
![titter](https://user-images.githubusercontent.com/58807337/163297064-1e4a461a-6447-4705-b8ca-926ded30c8e4.png)

## Added Tests?
No tests were added but all previous tests were passed.
![test](https://user-images.githubusercontent.com/58807337/163297114-60fccdd1-3d08-4588-8837-32a4ce43a44c.png)


## Added Documentation?
No Documentation was necessary.

## Note
- Social Card contains image, title and description too. Clicking on the post will redirect you to https://app.opensauced.pizza

