### PR TITLE
fix: avoid duplicate repos

### DIFF
--- a/src/lib/repoStatusCode.js
+++ b/src/lib/repoStatusCode.js
@@ -1,10 +1,10 @@
 export async function repoStatusCode(repoUrl) {
   const apiRepoUrl = `https://api.github.com/repos/${repoUrl}`;
   const response = await fetch(apiRepoUrl);
-
+  const {full_name} = await response.json();
   if (apiRepoUrl !== response.url) {
-    return 301;
+    return [301, full_name];
   } else {
-    return response.status;
+    return [response.status,""];
   }
 }

--- a/src/lib/repoStatusCode.test.js
+++ b/src/lib/repoStatusCode.test.js
@@ -3,19 +3,26 @@ import {repoStatusCode} from "./repoStatusCode";
 describe("Test: repoStatusCode()", () => {
   test("github/gh-ost should return 200", async() => {
     const repoUrl = "github/gh-ost";
-    const result = await repoStatusCode(repoUrl);
+    const [result] = await repoStatusCode(repoUrl);
     expect(result).toBe(200);
   });
 
   test("github/ghost should return 404", async() => {
     const repoUrl = "github/ghost";
-    const result = await repoStatusCode(repoUrl);
+    const [result] = await repoStatusCode(repoUrl);
     expect(result).toBe(404);
   });
 
-  test("bdougie/open-sauced should return 200", async() => {
+  test("open-sauced/open-sauced should return 200", async() => {
     const repoUrl = "open-sauced/open-sauced";
-    const result = await repoStatusCode(repoUrl);
+    const [result] = await repoStatusCode(repoUrl);
     expect(result).toBe(200);
+  });
+
+  test("finitesingularity/tau should return 301", async() => {
+    const repoUrl = "finitesingularity/tau";
+    const [result, newFullName] = await repoStatusCode(repoUrl);
+    expect(result).toBe(301);
+    expect(newFullName).toBe("Team-TAU/tau");
   });
 });

--- a/src/styles/Button.jsx
+++ b/src/styles/Button.jsx
@@ -42,6 +42,8 @@ const Button = styled.button`
   }
 
   &:disabled {
+    background: ${colors.lighterGrey};
+    color: ${colors.darkestGrey};
     cursor: not-allowed;
   }
 `;


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR fixes #1460 and fixes #1462.
This PR disables the repo add button while the goal adding API request is in flight.

The scope moved around a little on this one because I found little things to do as I went.
- changes the style on `InputButton` in the disabled state, so the cursor isn't the only visual indication.
- adjusts the comparison with existing goals to use lowercase since `isValidRepoUrl()`
- returns new full name with 301 status code from `repoStatusCode()` and pre-fills the form input with it
- fixes tests for new return for for `repoStatusCode()`.

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
#1460, #1462
## Mobile & Desktop Screenshots/Recordings
These are screenshots with the button duplicated with disabled state (just to show the difference, the app still only has one button).
<!-- Visual changes require screenshots -->
![image](https://user-images.githubusercontent.com/3792749/189798865-c56e2da8-d6b6-48d6-9b94-63a9e1c09e72.png)
![image](https://user-images.githubusercontent.com/3792749/189798913-d9e3361e-603c-499c-8672-d967f27ff797.png)


## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?
![rage click](https://media.giphy.com/media/Hr2rEQlFrDpCFu9Qt0/giphy.gif)


<!-- note: PRs with deleted sections will be marked invalid -->

